### PR TITLE
Exercise PD.T05: changed "Theorem PIP stylistic inspiration" to "Theorem...

### DIFF
--- a/src/section-PD.xml
+++ b/src/section-PD.xml
@@ -443,7 +443,7 @@ A=
 </exercise>
 
 <exercise type="T" number="05" rough="three dimension facts as with-equality-iff">
-<problem contributor="robertbeezer">Trivially, if $U$ and $V$ are two subspaces of $W$, then $\dimension{U}=\dimension{V}$.  Combine this fact, <acroref type="theorem" acro="PSSD" />, and <acroref type="theorem" acro="EDYES" /> all into one grand combined theorem.  You might look to <acroref type="theorem" acro="PIP" /> stylistic inspiration.  (Notice this problem does not ask you to prove anything.  It just asks you to roll up three theorems into one compact, logically equivalent statement.)
+<problem contributor="robertbeezer">Trivially, if $U$ and $V$ are two subspaces of $W$, then $\dimension{U}=\dimension{V}$.  Combine this fact, <acroref type="theorem" acro="PSSD" />, and <acroref type="theorem" acro="EDYES" /> all into one grand combined theorem.  You might look to <acroref type="theorem" acro="PIP" /> for stylistic inspiration.  (Notice this problem does not ask you to prove anything.  It just asks you to roll up three theorems into one compact, logically equivalent statement.)
 </problem>
 </exercise>
 


### PR DESCRIPTION
... PIP for stylistic inspiration" (Jenna)

The word "for" was missing between "Theorem PIP" and "stylistic inspiration" in Section PD, Exercise PD.T05. Line 446.
