### PR TITLE
Sage LTS: got rid of unnecessary "a" (Jenna)

### DIFF
--- a/src/section-LT.xml
+++ b/src/section-LT.xml
@@ -244,7 +244,7 @@ You can experiment with <code>T_symbolic</code>, evaluating it at triples of rat
 </input>
 </sage>
 
-You can now, of course, experiment with <code>T</code> via tab-completion, but we will explain the various properties of a Sage linear transformations as we work through this chapter.  Even some seemingly simple operations, such as printing <code>T</code> will require some explanation.  But for starters, we can evaluate <code>T</code>.
+You can now, of course, experiment with <code>T</code> via tab-completion, but we will explain the various properties of Sage linear transformations as we work through this chapter.  Even some seemingly simple operations, such as printing <code>T</code> will require some explanation.  But for starters, we can evaluate <code>T</code>.
 <sage>
 <input>u = vector(QQ, [3, -1, 2])
 w = T(u)


### PR DESCRIPTION
Line 247: changed "properties of a Sage linear transformations" to "properties of Sage linear transformations"
