### PR TITLE
Solution IVLT.M30: Matrices missing brackets

### DIFF
--- a/src/section-IVLT.xml
+++ b/src/section-IVLT.xml
@@ -1315,7 +1315,7 @@ is similar.
 <solution contributor="robertbeezer">(Another approach to this solution would follow <acroref type="example" acro="CIVLT" />.)<br /><br />
 Suppose that $\ltdefn{\ltinverse{S}}{M_{1,2}}{P_1}$ has a form given by
 <equation>
-<![CDATA[\lt{\ltinverse{S}}{\begin{matrix}z & w\end{matrix}}=\left(rz+sw\right)+\left(pz+qw\right)x]]>
+<![CDATA[\lt{\ltinverse{S}}{\begin{bmatrix}z & w\end{bmatrix}}=\left(rz+sw\right)+\left(pz+qw\right)x]]>
 </equation>
 where $r,\,s,\,p,\,q$ are unknown scalars.  Then
 <alignmath>
@@ -1334,7 +1334,7 @@ Equating coefficients of these two polynomials, and then equating coefficients o
 </alignmath>
 This system has a unique solution: $r=1$, $s=-1$, $p=-2$, $q=3$.  So the desired inverse linear transformation is
 <equation>
-<![CDATA[\lt{\ltinverse{S}}{\begin{matrix}z & w\end{matrix}}=\left(z-w\right)+\left(-2z+3w\right)x]]>
+<![CDATA[\lt{\ltinverse{S}}{\begin{bmatrix}z & w\end{bmatrix}}=\left(z-w\right)+\left(-2z+3w\right)x]]>
 </equation>
 Notice that the system of 4 equations in 4 variables could be split into two systems, each with two equations in two variables (and identical coefficient matrices).  After making this split, the solution might feel like computing the inverse of a matrix (<acroref type="theorem" acro="CINM" />).   Hmmmm.
 </solution>


### PR DESCRIPTION
Lines 1318 and 1337: Not sure if I corrected them...correctly. I just changed {matrix} to {bmatrix} like the other matrices.
